### PR TITLE
update sanitizer dependency to 0.1.3, which allows for numeric values…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "dank-map": "~0.1.0",
-    "sanitizer": "0.0.15"
+    "sanitizer": "0.1.3"
   },
   "devDependencies": {
     "nodeunit": "^0.9.1"

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,17 @@ exports["basic test"] = function (test) {
 		}
 		, g : "<![CDATA[ test & data ]]>"
 		, h : "<!asdf&"
+		, i : {
+			"@" : {
+				numeric : 42
+			}
+		}
+		, j : {
+			"@" : {
+				numeric : 42
+			}
+			, "#" : "value"
+		}
 	});
 
 	var expect = ''
@@ -41,8 +52,10 @@ exports["basic test"] = function (test) {
 		+ '</a>\n'
 		+ '<g><![CDATA[ test & data ]]></g>\n'
 		+ '<h>&lt;!asdf&amp;</h>\n'
+		+ '<i numeric="42" />\n'
+		+ '<j numeric="42">value</j>\n'
 		;
-	
+
 	test.equal(expect, str);
 	test.done();
 }


### PR DESCRIPTION
… to be escaped.

Resolves issue that caused objects with numeric attribute values to throw an error. The issue is rooted in the use of an older version of the [sanitizer](https://github.com/theSmaw/Caja-HTML-Sanitizer) dependency, which did not cast numeric values as a string before attempting to escape the value. The [sanitizer](https://github.com/theSmaw/Caja-HTML-Sanitizer) maintainers have resolved this issue and the package now properly casts numeric values as a string before escaping.

**Modifications**
- Updates [sanitizer](https://github.com/theSmaw/Caja-HTML-Sanitizer) dependency to v 0.1.3
- Add tests for numeric attributes

**Example of error**

test.js

```
var o2xml = require('object-to-xml');
var obj = {
  element : {
    "@" : {
      numeric : 42
    }
  }
};

console.log(o2xml(obj));
```

error: 

```
porkchop:barcode fletch$ node test.js 
/path/to/project/node_modules/sanitizer/sanitizer.js:168
    return s.replace(ampRe, '&amp;').replace(ltRe, '&lt;').replace(gtRe, '&gt;')
             ^

TypeError: s.replace is not a function
    at Object.escapeAttrib [as escape] (/path/to/project/node_modules/sanitizer/sanitizer.js:168:14)
    at Number.<anonymous> (/path/to/project/node_modules/object-to-xml/index.js:18:36)
    at doCall (/path/to/project/node_modules/dank-map/index.js:93:14)
    at map (/path/to/project/node_modules/dank-map/index.js:70:4)
    at Object.<anonymous> (/path/to/project/node_modules/object-to-xml/index.js:13:17)
    at doCall (/path/to/project/node_modules/dank-map/index.js:93:14)
    at map (/path/to/project/node_modules/dank-map/index.js:70:4)
    at objectToXML (/path/to/project/node_modules/object-to-xml/index.js:9:2)
    at Object.<anonymous> (/path/to/project/test.js:10:13)
    at Module._compile (module.js:541:32)
```
