### PR TITLE
Correction of '#' management for false|'0' values

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ var each = require('dank-each');
 module.exports = function objectToXML(obj, namespace, depth) {
 	var xml = [];
 	depth = depth || 0;
-	
+
 	each(obj, function (key, value) {
 		var attributes = '';
-		
+
 		if (key === '@') {
 			return;
 		}
@@ -23,8 +23,8 @@ module.exports = function objectToXML(obj, namespace, depth) {
 					return key + '="' + sanitizer.escape(value) + '"';
 				}
 			}, true).join(' ');
-			
-			if (value['#']) {
+
+			if (value['#'] !== undefined) {
 				value = value['#'];
 			}
 			else if (Object.keys(value).length === 1 && value.hasOwnProperty('@')) {
@@ -33,13 +33,13 @@ module.exports = function objectToXML(obj, namespace, depth) {
 				value = null;
 			}
 		}
-		
+
 		if (Array.isArray(value)) {
 			each(value, function (ix, value) {
 				var tmp = {};
-				
+
 				tmp[key] = value;
-				
+
 				xml.push(objectToXML(tmp, namespace, depth));
 			});
 		}
@@ -47,9 +47,9 @@ module.exports = function objectToXML(obj, namespace, depth) {
 			for (var x = 0; x < depth; x++) {
 				xml.push('  ');
 			}
-		
+
 			xml.push('<' + ((namespace) ? namespace + ':' : '') + key + ((attributes) ? ' ' + attributes : ''))
-			
+
 			//check to see if key is a ?something?
 			if (/^\?.*\?$/.test(key)) {
 				xml.push('>\n');
@@ -62,16 +62,16 @@ module.exports = function objectToXML(obj, namespace, depth) {
 			for (var x = 0; x < depth; x++) {
 				xml.push('  ');
 			}
-			
+
 			xml.push('<' + ((namespace) ? namespace + ':' : '') + key + ((attributes) ? ' ' + attributes : '') + '>')
-			
+
 			if (value && value.constructor.name == 'Date') {
 				xml.push(fixupDate(value));
 			}
 			else if (typeof (value) == 'object') {
 				xml.push('\n');
 				xml.push(objectToXML(value, namespace, depth + 1));
-				
+
 				for (var x = 0; x < depth; x++) {
 					xml.push('  ');
 				}
@@ -83,14 +83,14 @@ module.exports = function objectToXML(obj, namespace, depth) {
 						value = sanitizer.escape(value);
 					}
 				}
-				
+
 				xml.push(value);
 			}
-			
+
 			xml.push('</' + ((namespace) ? namespace + ':' : '') + key.split(/\ /)[0] + '>\n')
 		}
 	});
-	
+
 	return xml.join('');
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "object-to-xml",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Convert any object to XML",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi,
I would like to submit this modification in order to manage false or zero values passed on the '#' attributes. As of now they are not converted correctly in xml and creates the following pattern:
`<node><#>0<#/></node>` instead of `<node>0</node>`.

This is the first time that i make a pr on a project so don't hesitate to tell me if this is not the correct procedure of if anything is missing/wrong.

Best regards,
Maxime Fadlane